### PR TITLE
Always ignore 'Do Not Disturb'-related messages

### DIFF
--- a/lib/lita/handlers/whoami.rb
+++ b/lib/lita/handlers/whoami.rb
@@ -65,7 +65,10 @@ module Lita
       end
 
       def invalid_thing?(thing, chat)
-        config.bots.include?(chat.message.source.user.name)
+        return true if chat.message.body.include? 'currently in Do Not Disturb mode'
+        return true if config.bots.include?(chat.message.source.user.name)
+
+        false
       end
 
       Lita.register_handler(self)

--- a/spec/lita/handlers/whoami_spec.rb
+++ b/spec/lita/handlers/whoami_spec.rb
@@ -19,6 +19,12 @@ describe Lita::Handlers::Whoami, lita_handler: true do
     expect(replies).to be_empty
   end
 
+  it "definitely won't accept 'Do Not Disturb'-related messages" do
+    send_command 'taylor is currently in Do Not Disturb mode and may not be alerted of this message right away. If it’s urgent, click here...'
+
+    expect(replies).to be_empty
+  end
+
   it "can tell you what people are" do
     send_command("taylor is a bad programmer")
     send_command("who is taylor")


### PR DESCRIPTION
Seems some rouge messages from Slackbot were still making it through (somehow). This ensures that never happens.
